### PR TITLE
Add conversion utils to Rust and TS SDKs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7561,7 +7561,7 @@ dependencies = [
 
 [[package]]
 name = "xorca"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/js-client/package.json
+++ b/js-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@orca-so/xorca",
   "description": "The xORCA JS client for interacting with the xORCA staking program on Solana.",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "license": "CUSTOM",
   "keywords": [
     "solana",

--- a/js-client/src/utils/conversion.test.ts
+++ b/js-client/src/utils/conversion.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { convertOrcaToXorca, convertXorcaToOrca } from './conversion';
+
+describe('conversion utils', () => {
+  it('convertOrcaToXorca handles nominal large values', () => {
+    const out = convertOrcaToXorca(100_000_000_000n, 400_000_000_000n, 200_000_000_000n);
+    // With virtual offsets: supply=200_000_000_100, non-escrowed=400_000_000_100 =>
+    // 100_000_000_000 * 200_000_000_100 / 400_000_000_100 = 50_000_000_012 (floored)
+    expect(out).toBe(50_000_000_012n);
+  });
+
+  it('convertXorcaToOrca handles nominal large values', () => {
+    const out = convertXorcaToOrca(50_000_000_000n, 500_000_000_000n, 250_000_000_000n);
+    // With virtual offsets: supply=250_000_000_100, non-escrowed=500_000_000_100 =>
+    // 50_000_000_000 * 500_000_000_100 / 250_000_000_100 = 99_999_999_980 (floored)
+    expect(out).toBe(99_999_999_980n);
+  });
+
+  it('convertXorcaToOrca throws on zero supply/non-escrowed', () => {
+    expect(() => convertXorcaToOrca(1n, 0n, 0n)).toThrowError();
+  });
+});

--- a/js-client/src/utils/conversion.ts
+++ b/js-client/src/utils/conversion.ts
@@ -1,0 +1,39 @@
+// Off-chain conversion helpers that mirror the on-chain staking math.
+
+export const VIRTUAL_XORCA_SUPPLY = 100n;
+export const VIRTUAL_NON_ESCROWED_ORCA_AMOUNT = 100n;
+
+/**
+ * Convert an ORCA amount to xORCA using the same virtual-offset defense as the on-chain program.
+ * Returns the amount of xORCA to mint (integer division floors).
+ */
+export function convertOrcaToXorca(
+  orcaAmountToConvert: bigint,
+  nonEscrowedOrcaAmount: bigint,
+  xorcaSupply: bigint
+): bigint {
+  if (xorcaSupply === 0n || nonEscrowedOrcaAmount === 0n) {
+    return orcaAmountToConvert;
+  }
+  const xorcaSupplyWithVirtual = xorcaSupply + VIRTUAL_XORCA_SUPPLY;
+  const nonEscrowedWithVirtual = nonEscrowedOrcaAmount + VIRTUAL_NON_ESCROWED_ORCA_AMOUNT;
+  return (orcaAmountToConvert * xorcaSupplyWithVirtual) / nonEscrowedWithVirtual;
+}
+
+/**
+ * Convert an xORCA amount to ORCA using the same virtual-offset defense as the on-chain program.
+ * Returns the amount of ORCA to withdraw (integer division floors).
+ * Throws if supply or non-escrowed amount is zero.
+ */
+export function convertXorcaToOrca(
+  xorcaAmountToConvert: bigint,
+  nonEscrowedOrcaAmount: bigint,
+  xorcaSupply: bigint
+): bigint {
+  if (xorcaSupply === 0n || nonEscrowedOrcaAmount === 0n) {
+    throw new Error('Zero xORCA supply or non-escrowed ORCA amount; conversion is invalid');
+  }
+  const xorcaSupplyWithVirtual = xorcaSupply + VIRTUAL_XORCA_SUPPLY;
+  const nonEscrowedWithVirtual = nonEscrowedOrcaAmount + VIRTUAL_NON_ESCROWED_ORCA_AMOUNT;
+  return (xorcaAmountToConvert * nonEscrowedWithVirtual) / xorcaSupplyWithVirtual;
+}

--- a/js-client/src/utils/index.ts
+++ b/js-client/src/utils/index.ts
@@ -16,6 +16,7 @@ import {
 } from '@solana/kit';
 import { getAddressEncoder } from '@solana/addresses';
 import { getTokenDecoder, getMintDecoder } from '@solana-program/token';
+export * from './conversion';
 
 const TOKEN_PROGRAM_ADDRESS = 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA' as Address;
 const ASSOCIATED_TOKEN_PROGRAM_ADDRESS = 'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL' as Address;

--- a/rust-client/Cargo.toml
+++ b/rust-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xorca"
 description = "A Rust client library for interacting with the xORCA staking program on Solana."
-version = "0.1.3"
+version = "0.1.4"
 homepage = "https://orca.so"
 repository = "https://github.com/orca-so/xorca"
 license-file = "../LICENSE"

--- a/rust-client/src/conversion.rs
+++ b/rust-client/src/conversion.rs
@@ -1,0 +1,146 @@
+//! Off-chain conversion helpers that mirror the on-chain staking math. These
+//! allow clients to predict xORCA/ORCA amounts using the exact same logic and
+//! virtual offsets as the program.
+
+use thiserror::Error;
+
+// ----------------------------------
+// CONVERSION FUNCTIONS
+// ----------------------------------
+
+/// Convert an ORCA amount to xORCA using the same virtual-offset defense as the
+/// on-chain program. Returns the amount of xORCA to mint (integer division floors).
+pub fn convert_orca_to_xorca(
+    orca_amount_to_convert: u64,
+    non_escrowed_orca_amount: u64,
+    xorca_supply: u64,
+) -> Result<u64, ConversionError> {
+    if xorca_supply == 0 || non_escrowed_orca_amount == 0 {
+        return Ok(orca_amount_to_convert);
+    }
+
+    let (non_escrowed_with_virtual_offset, xorca_supply_with_virtual_offset) =
+        apply_virtual_offsets(non_escrowed_orca_amount, xorca_supply)?;
+
+    let out_xorca = (orca_amount_to_convert as u128)
+        .checked_mul(xorca_supply_with_virtual_offset)
+        .ok_or(ConversionError::Arithmetic)?
+        .checked_div(non_escrowed_with_virtual_offset)
+        .ok_or(ConversionError::Arithmetic)?;
+
+    out_xorca
+        .try_into()
+        .map_err(|_| ConversionError::Arithmetic)
+}
+
+/// Convert an xORCA amount to ORCA using the same virtual-offset defense as the
+/// on-chain program. Returns the amount of ORCA to withdraw (integer division floors).
+pub fn convert_xorca_to_orca(
+    xorca_amount_to_convert: u64,
+    non_escrowed_orca_amount: u64,
+    xorca_supply: u64,
+) -> Result<u64, ConversionError> {
+    if xorca_supply == 0 || non_escrowed_orca_amount == 0 {
+        return Err(ConversionError::ZeroSupplyOrNonEscrowed);
+    }
+
+    let (non_escrowed_with_virtual_offset, xorca_supply_with_virtual_offset) =
+        apply_virtual_offsets(non_escrowed_orca_amount, xorca_supply)?;
+
+    let out_orca = (xorca_amount_to_convert as u128)
+        .checked_mul(non_escrowed_with_virtual_offset)
+        .ok_or(ConversionError::Arithmetic)?
+        .checked_div(xorca_supply_with_virtual_offset)
+        .ok_or(ConversionError::Arithmetic)?;
+
+    out_orca.try_into().map_err(|_| ConversionError::Arithmetic)
+}
+
+// ----------------------------------
+// ERROR
+// ----------------------------------
+
+#[derive(Debug, Error, PartialEq, Eq)]
+/// Errors that occur during conversion (overflow or invalid inputs).
+pub enum ConversionError {
+    #[error("arithmetic overflow or invalid inputs")]
+    Arithmetic,
+    #[error("zero xORCA supply or non-escrowed ORCA amount; conversion is invalid")]
+    ZeroSupplyOrNonEscrowed,
+}
+
+// ----------------------------------
+// VIRTUAL OFFSETS
+// ----------------------------------
+
+/// Virtual supply offset applied to xORCA to defend against vault inflation.
+pub const VIRTUAL_XORCA_SUPPLY: u128 = 100;
+/// Virtual ORCA offset applied to non-escrowed ORCA to defend against vault inflation.
+pub const VIRTUAL_NON_ESCROWED_ORCA_AMOUNT: u128 = 100;
+
+fn apply_virtual_offsets(
+    non_escrowed_orca_amount: u64,
+    xorca_supply: u64,
+) -> Result<(u128, u128), ConversionError> {
+    let xorca_supply_with_virtual_offset = (xorca_supply as u128)
+        .checked_add(VIRTUAL_XORCA_SUPPLY)
+        .ok_or(ConversionError::Arithmetic)?;
+    let non_escrowed_with_virtual_offset = (non_escrowed_orca_amount as u128)
+        .checked_add(VIRTUAL_NON_ESCROWED_ORCA_AMOUNT)
+        .ok_or(ConversionError::Arithmetic)?;
+    Ok((
+        non_escrowed_with_virtual_offset,
+        xorca_supply_with_virtual_offset,
+    ))
+}
+
+// ----------------------------------
+// TESTS
+// ----------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn orca_to_xorca_zero_supply() {
+        assert_eq!(
+            convert_orca_to_xorca(10, 0, 0).unwrap(),
+            10,
+            "zero supply or non-escrowed should convert 1-1"
+        );
+    }
+
+    #[test]
+    fn orca_to_xorca_nominal() {
+        // Large values (9 decimal tokens): 100 ORCA, 400 non-escrowed, 200 xORCA supply
+        let out = convert_orca_to_xorca(100_000_000_000, 400_000_000_000, 200_000_000_000).unwrap();
+        // With virtual offsets: supply=200_000_000_100, non-escrowed=400_000_000_100 =>
+        // 100_000_000_000 * 200_000_000_100 / 400_000_000_100 = 50_000_000_012 (floored)
+        assert_eq!(out, 50_000_000_012);
+    }
+
+    #[test]
+    fn xorca_to_orca_zero_supply_errs() {
+        assert_eq!(
+            convert_xorca_to_orca(10, 0, 0).unwrap_err(),
+            ConversionError::ZeroSupplyOrNonEscrowed
+        );
+    }
+
+    #[test]
+    fn xorca_to_orca_nominal() {
+        // Large values (9 decimal tokens): xORCA 50, non-escrowed ORCA 500, xORCA supply 250
+        let out = convert_xorca_to_orca(50_000_000_000, 500_000_000_000, 250_000_000_000).unwrap();
+        // With virtual offsets: supply=250_000_000_100, non-escrowed=500_000_000_100 =>
+        // 50_000_000_000 * 500_000_000_100 / 250_000_000_100 = 99_999_999_980 (floored)
+        assert_eq!(out, 99_999_999_980);
+    }
+
+    #[test]
+    fn detects_overflow_on_large_product() {
+        // Force a multiply overflow in u128 when virtual asset amounts are added to u64::MAX inputs
+        let err = convert_orca_to_xorca(u64::MAX, u64::MAX, u64::MAX).unwrap_err();
+        assert_eq!(err, ConversionError::Arithmetic);
+    }
+}

--- a/rust-client/src/lib.rs
+++ b/rust-client/src/lib.rs
@@ -38,6 +38,7 @@
 
 #![allow(unexpected_cfgs)]
 
+pub mod conversion;
 #[allow(clippy::all, unused_imports)]
 mod generated;
 #[cfg(feature = "wasm")]
@@ -58,6 +59,7 @@ pub use generated::types::*;
 #[cfg(feature = "fetch")]
 pub(crate) use generated::*;
 
+pub use conversion::*;
 pub use pda::*;
 
 #[cfg(feature = "wasm")]


### PR DESCRIPTION
xORCA aggregators need to provide quotes for users. Exposing the xORCA conversion logic via the SDK will improve aggregator support.

- Added on-chain–equivalent ORCA/xORCA conversion helpers to the Rust SDK in `rust-client/src/conversion.rs`, re-exported via `lib.rs`, with unit tests and documented virtual offsets.
- Added matching BigInt conversion helpers to the JS client in `js-client/src/utils/conversion.ts` and re-exported through `utils/index.ts`; added vitest coverage for nominal and error cases.
- Ensured both SDKs expose consistent conversion math for off-chain consumers.

