### PR TITLE
Document xORCA sent to incinerator

### DIFF
--- a/solana-program/src/util/math.rs
+++ b/solana-program/src/util/math.rs
@@ -9,6 +9,9 @@ pub fn convert_orca_to_xorca(
     non_escrowed_orca_amount: u64,
     xorca_supply: u64,
 ) -> Result<u64, ProgramError> {
+    // Note: The following transaction sent 0.000_001 xORCA to the Incinerator.
+    //       Therefore, the xORCA token supply can never become 0 again.
+    //       https://solscan.io/tx/5bcCrmP9RySyHyoetvu9bTrihDFS9Mgv3S2fNDJtty2rR66Cm1z5SYp4ugXeZ5x9erDbAiuk4q6kASKLuQUBeUF8
     if (xorca_supply == 0) || (non_escrowed_orca_amount == 0) {
         return Ok(orca_amount_to_convert);
     }


### PR DESCRIPTION
# Context
We were informed via an Immunefi report that a vault inflation attack could theoretically be conducted by exploiting the zero xORCA supply short-circuit logic. The virtual assets in the exchange rate mechanism are designed to make vault inflation attacks unprofitable by forcing much of the attacker's donation amount to be lost to the vault. 

However, the whitehat demonstrated that if all stakers were to unstake such that the xORCA supply returns to 0, the attacker can use the short-circuit logic to reclaim the donation amount previously stuck in the vault and thus make the overall attack profitable.

Orca recognized the validity of the whitehat's report and classified the vulnerability as "Low" severity since the protocol has many stakers at this point and the likelihood that all stakers unstake their xORCA such that the supply returns to 0 is very low. We thank the whitehat for responsibly disclosing this vulnerability and have paid the appropriate bounty. 

# Solution
The most minimally invasive solution was to send a small quantity of xORCA to the incinerator's ATA. This means that the xORCA supply can now never return to 0 and the attack vector has been neutralized. We document this transfer of xORCA to the incinerator in this PR.